### PR TITLE
ansible-cli

### DIFF
--- a/scripts/ansible-cli
+++ b/scripts/ansible-cli
@@ -11,40 +11,34 @@ usage()
     echo 'You should provide the following env vars:'
     echo ''
     echo "$0"
+    echo '  * `(ANSIBLE_MODULE)`: Module to use. Default: `shell`'
+    echo '  * `(ANSIBLE_MODULE_ARGS)`: Ad-hoc command to use with the module. Exemple: "echo foo"'
+    echo '  * `(ANSIBLE_TARGET_PATTERN)`: which managed nodes or groups you want to execute against. Default: `all`'
+    echo '  * `(ANSIBLE_LIMIT_HOSTS)`: select a subset of the inventory'
     echo '  * `(SSH_PRIVATE_KEY)`: SSH key to use to connect on servers'
     echo '  * `(SSH_PRIVATE_KEYS)`: SSH key array to use to connect on servers. Example: ["PRIVATE_KEY","PRIVATE_KEY"]'
     echo '  * `(BASTION_URL)`: [DEPRECATED] SSH URL of the bastion server. Example: `admin@myserver.com`'
     echo '  * `(SSH_JUMP_URL)`: SSH ProxyJump URL used with `ssh ProxyJump`. Example: `user1@Bastion1,user2@Bastion2`'
-    echo '  * `(TAGS)`: Only run plays and tasks tagged with these values'
-    echo '  * `(SKIP_TAGS)`: Only run plays and tasks whose tags do not match these values'
     echo '  * `(EXTRA_ANSIBLE_VARS)`: [DEPRECATED] Ansible extra-vars, set additional variables, json dict format.'
     echo '  * `(ANSIBLE_EXTRA_VARS)`: Ansible extra-vars, set additional variables, json dict format.'
     echo '  * `(EXTRA_ANSIBLE_ARGS)`: [DEPRECATED] Additional ansible arguments'
     echo '  * `(ANSIBLE_EXTRA_ARGS)`: Additional ansible arguments'
     echo '  * `(ANSIBLE_REMOTE_USER)`: Ansible remote user. Default: `admin`.'
-    echo '  * `(ANSIBLE_LIMIT_HOSTS)`: select a subset of the inventory'
-    echo '  * `(ANSIBLE_GALAXY_EXTRA_ARGS)`: Additional ansible-galaxy arguments'
-    echo '  * `(ANSIBLE_VAULT_PASSWORD)`: Vault password if you use [Ansible Vault](https://docs.ansible.com/ansible/latest/user_guide/vault.html) files'
-    echo '  * `(ANSIBLE_FORCE_GALAXY)`: Force to run Ansible galaxy to updated eventual cached ansible roles. Default: `false`.'
-    echo '  * `(ANSIBLE_PLAYBOOK_NAME)`: Name of the ansible playbook to run. Default: `site.yml`.'
-    echo '  * `(ANSIBLE_PLAYBOOK_PATH)`: Path of the ansible playbook to run. Default: `ansible-playbook`.'
     echo '  * `(DEBUG)`: Run in debug mode'
     echo ''
-    echo 'ec2 vars:'
+    echo 'ec2.py vars:'
     echo '  * `(AWS_INVENTORY)`: If the Amazon EC2 dynamic inventory need to be used or no, can be eiter `true`, `false` or `auto`. `auto` checks if `AWS_ACCESS_KEY_ID` is set or not. Default: `auto`.'
     echo '  * `(AWS_ACCESS_KEY_ID)`: Used by Amazon EC2 dynamic inventory'
     echo '  * `(AWS_SECRET_ACCESS_KEY)`: Used by Amazon EC2 dynamic inventory'
     echo '  * `(EC2_VPC_DESTINATION_VARIABLE)`: Can be either `ip_address` for public ip address or `private_ip_address`, see [ec2.ini](https://github.com/ansible/ansible/blob/devel/contrib/inventory/ec2.ini). Default: `private_ip_address`.'
     echo ''
-    echo 'azure_rm vars:'
+    echo 'azure_rm.py vars:'
     echo '  * `(AZURE_INVENTORY)`: If the Azure dynamic inventory need to be used or no, can be eiter `true`, `false` or `auto`. `auto` checks if `AZURE_SUBSCRIPTION_ID` is set or not. Default: `auto`.'
     echo '  * `(AZURE_SUBSCRIPTION_ID)`: Used by Azure dynamic inventory'
     echo '  * `(AZURE_TENANT_ID)`: Used by Azure dynamic inventory'
     echo '  * `(AZURE_CLIENT_ID)`: Used by Azure dynamic inventory'
     echo '  * `(AZURE_SECRET)`: Used by Azure dynamic inventory'
     echo '  * `(AZURE_USE_PRIVATE_IP)`: Can be either `True` or `False`, see [azure_rm.py](https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/azure_rm.py). Default: `True`.'
-    echo '  * `(ANSIBLE_PLUGIN_AZURE_PLAIN_HOST_NAMES)`: By default this plugin will use globally unique host names. This option allows you to override that, and use the name that matches the old inventory script naming.. Default: `False`.'
-    echo '  note: Ansible `azure_rm` plugin is used for ansible `>= 2.8` else `azure_rm.py` script will be used'
     echo ''
     exit 1
 }
@@ -52,32 +46,15 @@ if [ -n "$1" ]; then usage; fi
 
 source ansible-common.sh
 
-#
-# Set defaults
-#
-export ANSIBLE_PLAYBOOK_PATH="${ANSIBLE_PLAYBOOK_PATH:-ansible-playbook}"
-export ANSIBLE_PLAYBOOK_NAME="${ANSIBLE_PLAYBOOK_NAME:-site.yml}"
-export ANSIBLE_FORCE_GALAXY="${ANSIBLE_FORCE_GALAXY:-false}"
-export ANSIBLE_VAULT_PASSWORD="${ANSIBLE_VAULT_PASSWORD:-fake}"
-
-if [ "${ANSIBLE_FORCE_GALAXY,,}" == "true" ]; then
-  ANSIBLE_GALAXY_EXTRA_ARGS="${ANSIBLE_GALAXY_EXTRA_ARGS} --force"
-fi
+# default
+export ANSIBLE_MODULE=${ANSIBLE_MODULE:-shell}
+export ANSIBLE_TARGET_PATTERN=${ANSIBLE_TARGET_PATTERN:-all}
 
 
-# Vault password
-echo ${ANSIBLE_VAULT_PASSWORD} > $ANSIBLE_PLAYBOOK_PATH/.vault-password
-#export DEFAULT_VAULT_PASSWORD_FILE="$ANSIBLE_PLAYBOOK_PATH/.vault-password"
 
-cd $ANSIBLE_PLAYBOOK_PATH
-
-if [ -f "requirements.yml" ]; then
-    ansible-galaxy install -r requirements.yml --roles-path=roles -v ${ANSIBLE_GALAXY_EXTRA_ARGS}
-fi
-
-echo "######################## Running ansible playbook $ANSIBLE_PLAYBOOK_NAME"
+echo "######################## Running ansible cli"
 
 ansible --version
-ansible-playbook -u ${ANSIBLE_REMOTE_USER} --vault-password-file=.vault-password ${ANSIBLE_PLAYBOOK_NAME} -e cycloid_workdir=${CYCLOID_WORKDIR} --diff ${ANSIBLE_EXTRA_ARGS}
+ansible -e cycloid_workdir=${CYCLOID_WORKDIR} ${ANSIBLE_TARGET_PATTERN} -u ${ANSIBLE_REMOTE_USER} -m ${ANSIBLE_MODULE} ${ANSIBLE_EXTRA_ARGS}
 
 exit $?

--- a/scripts/ansible-common.sh
+++ b/scripts/ansible-common.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+set -e
+
+if [ -n "$DEBUG" ]; then
+  set -x
+fi
+
+export CYCLOID_WORKDIR=$PWD
+
+export ANSIBLE_VERSION="$(ansible --version | head -n1 | awk '{print $2}')"
+export ANSIBLE_REMOTE_USER="${ANSIBLE_REMOTE_USER:-admin}"
+
+# Used to set a a default ssh multiplex. You can override it to disable it
+export EXTRA_ANSIBLE_SSH_ARGS="${EXTRA_ANSIBLE_SSH_ARGS:-"-o ControlMaster=auto -o ControlPersist=60s"}"
+export ANSIBLE_SSH_ARGS="${ANSIBLE_SSH_ARGS} ${EXTRA_ANSIBLE_SSH_ARGS}"
+export ANSIBLE_FORCE_COLOR="${ANSIBLE_FORCE_COLOR:-true}"
+export ANSIBLE_STDOUT_CALLBACK="${ANSIBLE_STDOUT_CALLBACK:-actionable}"
+
+# Default envvars for ec2.py
+export AWS_INVENTORY="${AWS_INVENTORY:-auto}"
+export AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-eu-west-1}"
+export EC2_VPC_DESTINATION_VARIABLE="${EC2_VPC_DESTINATION_VARIABLE:-private_ip_address}"
+
+# Default envvars for azure_rm.py
+export DEFAULT_ANSIBLE_PLUGIN_AZURE_HOST="${DEFAULT_ANSIBLE_PLUGIN_AZURE_HOST:-"(public_dns_hostnames + public_ipv4_addresses + private_ipv4_addresses) | first"}"
+export DEFAULT_ANSIBLE_PLUGIN_AZURE_HOST_PRIVATE="${DEFAULT_ANSIBLE_PLUGIN_AZURE_HOST_PRIVATE:-"(private_ipv4_addresses + public_dns_hostnames + public_ipv4_addresses) | first"}"
+export AZURE_INVENTORY="${AZURE_INVENTORY:-auto}"
+# Make sure args work for Ansible azure rm and https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/azure_rm.py
+export AZURE_TENANT="${AZURE_TENANT:-$AZURE_TENANT_ID}"
+export AZURE_USE_PRIVATE_IP="${AZURE_USE_PRIVATE_IP:-True}"
+export ANSIBLE_PLUGIN_AZURE_PLAIN_HOST_NAMES="${ANSIBLE_PLUGIN_AZURE_PLAIN_HOST_NAMES:-False}"
+export ANSIBLE_PLUGIN_AZURE_HOST="${ANSIBLE_PLUGIN_AZURE_HOST:-""}"
+
+# Keep compatibility with old namings
+export SSH_PRIVATE_KEY="${SSH_PRIVATE_KEY:-$BASTION_PRIVATE_KEY}"
+export EXTRA_ANSIBLE_VARS="${EXTRA_ANSIBLE_VARS:-$EXTRA_VARS}"
+export EXTRA_ANSIBLE_ARGS="${EXTRA_ANSIBLE_ARGS:-$EXTRA_ARGS}"
+export ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS:-$EXTRA_ANSIBLE_ARGS}"
+export ANSIBLE_EXTRA_VARS="${ANSIBLE_EXTRA_VARS:-$EXTRA_ANSIBLE_VARS}"
+
+#
+# Construct vars
+#
+if [ -n "$ANSIBLE_EXTRA_VARS" ]; then
+  echo $ANSIBLE_EXTRA_VARS | jq -M . > /tmp/extra_ansible_args.json
+  ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS} -e @/tmp/extra_ansible_args.json"
+fi
+if [ -n "$TAGS" ]; then
+  ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS} --tags $(echo $TAGS | jq -r '. | join(",")')"
+fi
+if [ -n "$SKIP_TAGS" ]; then
+  ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS} --skip-tags $(echo $SKIP_TAGS | jq -r '. | join(",")')"
+fi
+if [ "$AWS_INVENTORY" == "auto" ] && [ -n "$AWS_ACCESS_KEY_ID" ] || [ "${AWS_INVENTORY,,}" == "true" ]; then
+  # Render ec2.ini template from envvars
+  envsubst < /etc/ansible/hosts-template/ec2.ini.template > /etc/ansible/hosts/ec2.ini
+  cp /etc/ansible/hosts-template/ec2.py /etc/ansible/hosts/
+  ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS} -i /etc/ansible/hosts/ec2.py"
+fi
+
+if [ -z "${ANSIBLE_PLUGIN_AZURE_HOST}" ]; then
+  if [ "${AZURE_USE_PRIVATE_IP,,}" == "true" ]; then
+      export ANSIBLE_PLUGIN_AZURE_HOST="${DEFAULT_ANSIBLE_PLUGIN_AZURE_HOST_PRIVATE}"
+  else
+      export ANSIBLE_PLUGIN_AZURE_HOST="${DEFAULT_ANSIBLE_PLUGIN_AZURE_HOST}"
+  fi
+fi
+if [ "$AZURE_INVENTORY" == "auto" ] && [ -n "$AZURE_SUBSCRIPTION_ID" ] || [ "${AZURE_INVENTORY,,}" == "true" ]; then
+  if (( $(echo "${ANSIBLE_VERSION%.*} >= 2.8" |bc -l) )); then
+    # Render default.azure_rm.yml template from envvars
+    envsubst < /etc/ansible/hosts-template/default.azure_rm.yml.template > /etc/ansible/hosts/default.azure_rm.yml
+    ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS} -i /etc/ansible/hosts/default.azure_rm.yml"
+  else
+    cp /etc/ansible/hosts-template/azure_rm.py /etc/ansible/hosts/
+    ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS} -i /etc/ansible/hosts/azure_rm.py"
+  fi
+fi
+
+# Setup SSH access
+eval $(ssh-agent -s)
+
+# SSH keys
+KEY_ID=1
+if [ -n "$SSH_PRIVATE_KEYS" ]; then
+	IFS=$'\n'
+	for key in $(python -c "import json, os; print('\n'.join([ '%s' % v for v in json.loads(os.environ['SSH_PRIVATE_KEYS'].replace('\\n','\\\\\\\n'))]))"); do
+		# Use the first key as default SSH_PRIVATE_KEY if not defined
+		if [ -z "$SSH_PRIVATE_KEY" ]; then
+			SSH_PRIVATE_KEY=$(echo -e $key)
+			continue
+		fi
+		echo -e "$key" > /root/.ssh/id_rsa${KEY_ID}
+		chmod 600 /root/.ssh/id_rsa${KEY_ID}
+		ssh-add /root/.ssh/id_rsa${KEY_ID}
+		KEY_ID=$((KEY_ID+1))
+	done
+	unset IFS
+fi
+
+if [ -n "$SSH_PRIVATE_KEY" ]; then
+  # Root ssh key
+  echo "${SSH_PRIVATE_KEY}" > /root/.ssh/id_rsa
+  chmod 600  /root/.ssh/id_rsa
+  ssh-add /root/.ssh/id_rsa
+fi
+set -x
+if [ -n "$SSH_JUMP_URL" ]; then
+  export ANSIBLE_SSH_ARGS="$ANSIBLE_SSH_ARGS -o 'ProxyJump=$SSH_JUMP_URL' -o 'ForwardAgent=yes'"
+
+# DEPRECATED jump parameter for a bastion server. Use SSH_JUMP_URL instead
+elif [ -n "$BASTION_URL" ]; then
+  export ANSIBLE_SSH_ARGS="$ANSIBLE_SSH_ARGS"' -o ProxyCommand="ssh -W %h:%p -q '${BASTION_URL}'"'
+  #echo "ansible_ssh_common_args: '-o ProxyCommand=\"ssh -W %h:%p -q ${BASTION_URL}\"'" >> $ANSIBLE_PLAYBOOK_PATH/group_vars/all
+fi
+
+if [ -n "${ANSIBLE_LIMIT_HOSTS}" ]; then
+	export ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS} --limit ${ANSIBLE_LIMIT_HOSTS}"
+fi
+


### PR DESCRIPTION
I extracted common variables / logic from `ansible-runner` in order to create an `ansible-common`. 

`ansible-cli` and `ansible-runner` will `source` this file.

To use ansible-ci, there are three more variable:

`COMMAND`: this is the ansible module to run (shell, ping, etc.)
`ANSIBLE_MODULE_ARGS`: the _adhoc_ command to run
`TARGET_PATTERN`: which hosts group in the inventory to target (default to `all`)