### PR TITLE
azure: allow to change plain_host_names inventory flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ azure_rm vars:
   * `(AZURE_CLIENT_ID)`: Used by Azure dynamic inventory
   * `(AZURE_SECRET)`: Used by Azure dynamic inventory
   * `(AZURE_USE_PRIVATE_IP)`: Can be either `True` or `False`, see [azure_rm.py](https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/azure_rm.py). Default: `True`.
+  * `(ANSIBLE_PLUGIN_AZURE_PLAIN_HOST_NAMES)`: By default this plugin will use globally unique host names. This option allows you to override that, and use the name that matches the old inventory script naming.. Default: `False`.
   note: Ansible `azure_rm` plugin is used for ansible `>= 2.8` else `azure_rm.py` script will be used
 
 Example of pipeline configuration :

--- a/files/ansible/hosts-template/default.azure_rm.yml.template
+++ b/files/ansible/hosts-template/default.azure_rm.yml.template
@@ -48,6 +48,9 @@ hostvar_expressions:
   # if none are found, the first public IP address.
   ansible_host: $ANSIBLE_PLUGIN_AZURE_HOST
 
+# By default this plugin will use globally unique host names. This option allows you to override that, and use the name that matches the old inventory script naming.
+plain_host_names: $ANSIBLE_PLUGIN_AZURE_PLAIN_HOST_NAMES
+
 # places hosts in dynamically-created groups based on a variable value.
 keyed_groups:
 # places each host in a group named 'tag_(tag name)_(tag value)' for each tag on a VM.

--- a/scripts/ansible-runner
+++ b/scripts/ansible-runner
@@ -40,6 +40,7 @@ usage()
     echo '  * `(AZURE_CLIENT_ID)`: Used by Azure dynamic inventory'
     echo '  * `(AZURE_SECRET)`: Used by Azure dynamic inventory'
     echo '  * `(AZURE_USE_PRIVATE_IP)`: Can be either `True` or `False`, see [azure_rm.py](https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/azure_rm.py). Default: `True`.'
+    echo '  * `(ANSIBLE_PLUGIN_AZURE_PLAIN_HOST_NAMES)`: By default this plugin will use globally unique host names. This option allows you to override that, and use the name that matches the old inventory script naming.. Default: `False`.'
     echo '  note: Ansible `azure_rm` plugin is used for ansible `>= 2.8` else `azure_rm.py` script will be used'
     echo ''
     exit 1
@@ -71,6 +72,7 @@ export AZURE_INVENTORY="${AZURE_INVENTORY:-auto}"
 # Make sure args work for Ansible azure rm and https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/azure_rm.py
 export AZURE_TENANT="${AZURE_TENANT:-$AZURE_TENANT_ID}"
 export AZURE_USE_PRIVATE_IP="${AZURE_USE_PRIVATE_IP:-True}"
+export ANSIBLE_PLUGIN_AZURE_PLAIN_HOST_NAMES="${ANSIBLE_PLUGIN_AZURE_PLAIN_HOST_NAMES:-False}"
 export ANSIBLE_PLUGIN_AZURE_HOST="(public_dns_hostnames + public_ipv4_addresses) | first"
 if [ "${AZURE_USE_PRIVATE_IP,,}" == "true" ]; then
     export ANSIBLE_PLUGIN_AZURE_HOST="private_ipv4_addresses | first"

--- a/tests.py
+++ b/tests.py
@@ -421,10 +421,13 @@ j/McHvs4QerVnwQYfoRaNpFdQwNxL96tYM5M/5jH
         # Azure dynamic inventory should be used as AZURE_INVENTORY=true even if AZURE_SUBSCRIPTION_ID is not present
         environment={
             'AZURE_INVENTORY': 'true',
+            'ANSIBLE_PLUGIN_AZURE_PLAIN_HOST_NAMES': 'true',
         }
         r = self.drun(cmd="/usr/bin/ansible-runner", environment=environment)
         if float(self.ansible_version) >= 2.8:
             self.assertTrue(self.output_contains(r.output, '.*ansible-playbook.*-i /etc/ansible/hosts/default.azure_rm.yml'))
+            r = self.drun(cmd="cat /etc/ansible/hosts/default.azure_rm.yml")
+            self.assertTrue(self.output_contains(r.output, '^plain_host_names:.*true'))
         else:
             self.assertTrue(self.output_contains(r.output, '.*ansible-playbook.*-i /etc/ansible/hosts/azure_rm.py'))
         self.assertEquals(r.exit_code, 0)


### PR DESCRIPTION
Allow user to change plain_host_names azure inventory file for the few customers using instance legacy
name in their playbook.
This will help to keep compat using the new azure plugin

        plain_host_names:
          description:
            - By default this plugin will use globally unique host names.
              This option allows you to override that, and use the name that matches the old inventory script naming.
            - This is not the default, as these names are not truly unique, and can conflict with other hosts.
              The default behavior will add extra hashing to the end of the hostname to prevent such conflicts.