### PR TITLE
ansible: allow to put ssh key in ANSIBLE_EXTRA_VARS

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ boto
 boto3
 pyOpenSSL
 openshift
-azure-mgmt-resource
 azure-mgmt-compute
+azure-mgmt-resource

--- a/scripts/ansible-common.sh
+++ b/scripts/ansible-common.sh
@@ -43,6 +43,7 @@ export ANSIBLE_EXTRA_VARS="${ANSIBLE_EXTRA_VARS:-$EXTRA_ANSIBLE_VARS}"
 # Construct vars
 #
 if [ -n "$ANSIBLE_EXTRA_VARS" ]; then
+  # This will read the whole file in a loop, then replaces the newline(s) with a \\n.
   echo "$ANSIBLE_EXTRA_VARS" | sed ':a;N;$!ba;s/\n/\\n/g' | jq -M . > /tmp/extra_ansible_args.json
   ANSIBLE_EXTRA_ARGS=" -e @/tmp/extra_ansible_args.json ${ANSIBLE_EXTRA_ARGS}"
 fi

--- a/scripts/ansible-common.sh
+++ b/scripts/ansible-common.sh
@@ -43,7 +43,7 @@ export ANSIBLE_EXTRA_VARS="${ANSIBLE_EXTRA_VARS:-$EXTRA_ANSIBLE_VARS}"
 # Construct vars
 #
 if [ -n "$ANSIBLE_EXTRA_VARS" ]; then
-  echo $ANSIBLE_EXTRA_VARS | jq -M . > /tmp/extra_ansible_args.json
+  echo "$ANSIBLE_EXTRA_VARS" | sed ':a;N;$!ba;s/\n/\\n/g' | jq -M . > /tmp/extra_ansible_args.json
   ANSIBLE_EXTRA_ARGS=" -e @/tmp/extra_ansible_args.json ${ANSIBLE_EXTRA_ARGS}"
 fi
 if [ -n "$TAGS" ]; then


### PR DESCRIPTION
Variable form vault->concourse->bash->ansible the \n are not properly
rendered. Fixing the format to be able to use cycloid ssh creds into
ansible as ANSIBLE_EXTRA_VARS