### PR TITLE
ansible-runner: change ANSIBLE_EXTRA_ARGS order

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM alpine:3.10
+FROM alpine:3.12
 LABEL Description="Cycloid toolkit" Vendor="Cycloid.io" Version="1.0"
 MAINTAINER Cycloid.io
 
@@ -37,10 +37,9 @@ RUN ln -s /lib /lib64 \
             bc \
             tzdata \
             wget \
+            py-pip \
     && \
         update-ca-certificates \
-    && \
-        if [ ${PYTHON_VERSION} -eq 2 ]; then apk add --no-cache py-pip; fi \
     && \
         apk --upgrade add --no-cache --virtual \
             build-dependencies \

--- a/Dockerfile
+++ b/Dockerfile
@@ -96,4 +96,3 @@ RUN curl https://raw.githubusercontent.com/cycloidio/cycloid-cli/master/scripts/
 # Contain ec2.py dynamic inventory from https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/ec2.py
 COPY files/ansible /etc/ansible/
 COPY scripts/* /usr/bin/
-

--- a/scripts/ansible-common.sh
+++ b/scripts/ansible-common.sh
@@ -44,19 +44,19 @@ export ANSIBLE_EXTRA_VARS="${ANSIBLE_EXTRA_VARS:-$EXTRA_ANSIBLE_VARS}"
 #
 if [ -n "$ANSIBLE_EXTRA_VARS" ]; then
   echo $ANSIBLE_EXTRA_VARS | jq -M . > /tmp/extra_ansible_args.json
-  ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS} -e @/tmp/extra_ansible_args.json"
+  ANSIBLE_EXTRA_ARGS=" -e @/tmp/extra_ansible_args.json ${ANSIBLE_EXTRA_ARGS}"
 fi
 if [ -n "$TAGS" ]; then
-  ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS} --tags $(echo $TAGS | jq -r '. | join(",")')"
+  ANSIBLE_EXTRA_ARGS=" --tags $(echo $TAGS | jq -r '. | join(",")') ${ANSIBLE_EXTRA_ARGS}"
 fi
 if [ -n "$SKIP_TAGS" ]; then
-  ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS} --skip-tags $(echo $SKIP_TAGS | jq -r '. | join(",")')"
+  ANSIBLE_EXTRA_ARGS=" --skip-tags $(echo $SKIP_TAGS | jq -r '. | join(",")') ${ANSIBLE_EXTRA_ARGS}"
 fi
 if [ "$AWS_INVENTORY" == "auto" ] && [ -n "$AWS_ACCESS_KEY_ID" ] || [ "${AWS_INVENTORY,,}" == "true" ]; then
   # Render ec2.ini template from envvars
   envsubst < /etc/ansible/hosts-template/ec2.ini.template > /etc/ansible/hosts/ec2.ini
   cp /etc/ansible/hosts-template/ec2.py /etc/ansible/hosts/
-  ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS} -i /etc/ansible/hosts/ec2.py"
+  ANSIBLE_EXTRA_ARGS=" -i /etc/ansible/hosts/ec2.py ${ANSIBLE_EXTRA_ARGS}"
 fi
 
 if [ -z "${ANSIBLE_PLUGIN_AZURE_HOST}" ]; then
@@ -70,10 +70,10 @@ if [ "$AZURE_INVENTORY" == "auto" ] && [ -n "$AZURE_SUBSCRIPTION_ID" ] || [ "${A
   if (( $(echo "${ANSIBLE_VERSION%.*} >= 2.8" |bc -l) )); then
     # Render default.azure_rm.yml template from envvars
     envsubst < /etc/ansible/hosts-template/default.azure_rm.yml.template > /etc/ansible/hosts/default.azure_rm.yml
-    ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS} -i /etc/ansible/hosts/default.azure_rm.yml"
+    ANSIBLE_EXTRA_ARGS=" -i /etc/ansible/hosts/default.azure_rm.yml ${ANSIBLE_EXTRA_ARGS}"
   else
     cp /etc/ansible/hosts-template/azure_rm.py /etc/ansible/hosts/
-    ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS} -i /etc/ansible/hosts/azure_rm.py"
+    ANSIBLE_EXTRA_ARGS=" -i /etc/ansible/hosts/azure_rm.py ${ANSIBLE_EXTRA_ARGS}"
   fi
 fi
 
@@ -115,6 +115,5 @@ elif [ -n "$BASTION_URL" ]; then
 fi
 
 if [ -n "${ANSIBLE_LIMIT_HOSTS}" ]; then
-	export ANSIBLE_EXTRA_ARGS="${ANSIBLE_EXTRA_ARGS} --limit ${ANSIBLE_LIMIT_HOSTS}"
+	export ANSIBLE_EXTRA_ARGS=" --limit ${ANSIBLE_LIMIT_HOSTS} ${ANSIBLE_EXTRA_ARGS}"
 fi
-

--- a/tests.py
+++ b/tests.py
@@ -486,9 +486,9 @@ j/McHvs4QerVnwQYfoRaNpFdQwNxL96tYM5M/5jH
         }
         r = self.drun(cmd="/usr/bin/ansible-runner", environment=environment)
         if float(self.ansible_version) >= 2.8:
-            self.assertTrue(self.output_contains(r.output, '.*ansible-playbook.*-i /etc/ansible/hosts/ec2.py.*-i /etc/ansible/hosts/default.azure_rm.yml'))
+            self.assertTrue(self.output_contains(r.output, '.*ansible-playbook.*-i /etc/ansible/hosts/default.azure_rm.yml.*-i /etc/ansible/hosts/ec2.py'))
         else:
-            self.assertTrue(self.output_contains(r.output, '.*ansible-playbook.*-i /etc/ansible/hosts/ec2.py.*-i /etc/ansible/hosts/azure_rm.py'))
+            self.assertTrue(self.output_contains(r.output, '.*ansible-playbook.*-i /etc/ansible/hosts/azure_rm.py.*-i /etc/ansible/hosts/ec2.py'))
         self.assertEquals(r.exit_code, 0)
 
 class AnsibleCliTestCase(TestCase):
@@ -560,9 +560,9 @@ j/McHvs4QerVnwQYfoRaNpFdQwNxL96tYM5M/5jH
         }
         r = self.drun(cmd="/usr/bin/ansible-cli", environment=environment)
         if float(self.ansible_version) >= 2.8:
-            self.assertTrue(self.output_contains(r.output, '.*-i /etc/ansible/hosts/ec2.py.*-i /etc/ansible/hosts/default.azure_rm.yml'), msg=r.output)
+            self.assertTrue(self.output_contains(r.output, '.*-i /etc/ansible/hosts/default.azure_rm.yml.*-i /etc/ansible/hosts/ec2.py'), msg=r.output)
         else:
-            self.assertTrue(self.output_contains(r.output, '.*-i /etc/ansible/hosts/ec2.py.*-i /etc/ansible/hosts/azure_rm.py'))
+            self.assertTrue(self.output_contains(r.output, '.*-i /etc/ansible/hosts/azure_rm.py.*-i /etc/ansible/hosts/ec2.py'))
 
 class CycloidCliTestCase(TestCase):
 


### PR DESCRIPTION
ANSIBLE_EXTRA_ARGS have been set at the end of the line (but | or >
can't be used)

Closes:
  * https://github.com/cycloidio/docker-cycloid-toolkit/issues/16