### PR TITLE
pip: install msrestazure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pyOpenSSL
 openshift
 azure-mgmt-compute
 azure-mgmt-resource
+msrestazure


### PR DESCRIPTION
msrestazure packages is missing for azure dynamic inventory with ansible
2.9