### PR TITLE
dockerfile: Upgrade alpine and remove jinja workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM alpine:3.13
+FROM alpine:3.15
 LABEL Description="Cycloid toolkit" Vendor="Cycloid.io" Version="1.0"
 MAINTAINER Cycloid.io
 
@@ -56,8 +56,7 @@ RUN ln -s /lib /lib64 \
     && \
         pip${PYTHON_VERSION} install pip --upgrade && \
         pip${PYTHON_VERSION} install --upgrade --no-cache-dir -r /opt/requirements.txt && \
-        # avoid Jinja 2.11 until https://github.com/pallets/jinja/issues/1138
-        pip${PYTHON_VERSION} install --upgrade --no-cache-dir ansible==${ANSIBLE_VERSION} Jinja2==2.8 \
+        pip${PYTHON_VERSION} install --upgrade --no-cache-dir ansible==${ANSIBLE_VERSION} \
     && \
         ln -s $(which python${PYTHON_VERSION}) /bin/python \
     && \

--- a/scripts/ansible-cli
+++ b/scripts/ansible-cli
@@ -44,7 +44,7 @@ usage()
 }
 if [ -n "$1" ]; then usage; fi
 
-source ansible-common.sh
+source /usr/bin/ansible-common.sh
 
 # default
 export ANSIBLE_MODULE=${ANSIBLE_MODULE:-shell}

--- a/scripts/ansible-runner
+++ b/scripts/ansible-runner
@@ -50,7 +50,7 @@ usage()
 }
 if [ -n "$1" ]; then usage; fi
 
-source ansible-common.sh
+source /usr/bin/ansible-common.sh
 
 #
 # Set defaults


### PR DESCRIPTION
1) Simply apply minor upgrade on alpine image version.

2) Remove pinning on Jinja, the upstream bug is now fixed.

Also the pinned version of Jinja today produce a different issue
https://github.com/aws/aws-sam-cli/issues/3661
  File "/usr/lib/python3.9/site-packages/jinja2/utils.py", line 531, in <module>
    from markupsafe import Markup, escape, soft_unicode
ImportError: cannot import name 'soft_unicode' from 'markupsafe' (/usr/lib/python3.9/site-packages/markupsafe/__init__.py)

by using the latest version seems to fix both issues