### PR TITLE
Extract Terraform outputs to output-var with shell and YAML flavors

### DIFF
--- a/scripts/extract-terraform-outputs
+++ b/scripts/extract-terraform-outputs
@@ -6,7 +6,9 @@ usage()
     echo ''
     echo "$0"
     echo '  * `(TERRAFORM_METADATA_FILE)` Default `terraform/metadata`.'
-    echo '  * `(OUTPUT_ANSIBLE_VAR_FILE)` Default `output-var/all`. You might expect provide `ansible-playbook/group_vars/all`.'
+    echo '  * `(OUTPUT_ANSIBLE_VAR_FILE)` Ansible variables file. Default `output-var/all`. You might expect provide `ansible-playbook/group_vars/all`.'
+    echo '  * `(OUTPUT_ENV_VAR_FILE)` Shell environment variables file. Default `output-var/env`.'
+    echo '  * `(OUTPUT_YAML_VAR_FILE)` YAML variables file. Default `output-var/env.yml`.'
     echo ''
     exit 1
 }
@@ -16,10 +18,21 @@ if [ -n "$1" ]; then usage; fi
 # Set defaults
 export TERRAFORM_METADATA_FILE="${TERRAFORM_METADATA_FILE:-terraform/metadata}"
 export OUTPUT_ANSIBLE_VAR_FILE="${OUTPUT_ANSIBLE_VAR_FILE:-output-var/all}"
+export OUTPUT_ENV_VAR_FILE="${OUTPUT_ENV_VAR_FILE:-output-var/env}"
+export OUTPUT_YAML_VAR_FILE="${OUTPUT_YAML_VAR_FILE:-output-var/env.yml}"
 
 set -e
 
 mkdir -p $(dirname $OUTPUT_ANSIBLE_VAR_FILE)
+echo "############ Extracting Terraform output -> $OUTPUT_ANSIBLE_VAR_FILE"
 python -c 'import sys, yaml, json; yaml.safe_dump(json.load(sys.stdin), sys.stdout, default_flow_style=False)' < $TERRAFORM_METADATA_FILE | tee -a $OUTPUT_ANSIBLE_VAR_FILE
+
+mkdir -p $(dirname $OUTPUT_ENV_VAR_FILE)
+echo "############ Extracting Terraform output -> $OUTPUT_ENV_VAR_FILE"
+python -c "import sys, yaml, json; print('\n'.join([ '%s=%s' % (k,v) for k, v in json.load(sys.stdin).items()]))" < $TERRAFORM_METADATA_FILE | tee -a $OUTPUT_ENV_VAR_FILE
+
+mkdir -p $(dirname $OUTPUT_YAML_VAR_FILE)
+echo "############ Extracting Terraform output -> $OUTPUT_YAML_VAR_FILE"
+python -c "import sys, yaml, json; print('\n'.join([ '%s: \"%s\"' % (k,v) for k, v in json.load(sys.stdin).items()]))" < $TERRAFORM_METADATA_FILE | tee -a $OUTPUT_YAML_VAR_FILE
 
 exit $?

--- a/scripts/merge-stack-and-config
+++ b/scripts/merge-stack-and-config
@@ -75,7 +75,6 @@ fi
 # In case of ansible run, we might have provided terraform output metadata file.
 # Lookup if we are in this case. And generate those vars for ansible.
 if [ -f "$TERRAFORM_METADATA_FILE" ]; then
-  echo "############ Extracting Terraform output -> group_vars/all extract-terraform-outputs"
   OUTPUT_ANSIBLE_VAR_FILE=${MERGE_OUTPUT_PATH}/group_vars/all extract-terraform-outputs
 fi
 


### PR DESCRIPTION
When merging ansible stack and config, extract Terraform outputs to output-var with shell and YAML flavors (in addition of Ansible ones in merged-stack).
This allows to conveniently use Terraform outputs in the pipeline such as displaying information on newly created infra in cycloid-events like that: https://github.com/cycloidio/cycloid-demo-stacks/blob/408574faa1aad67b9b61584959a5afd0fb060ede/stack-nexus/pipeline/aws/pipeline.yml#L385-L396