### PR TITLE
ansible: allow to use raw cycloid creds

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,23 +56,23 @@ ansible-common:
 
 ec2 vars:
   * `(AWS_INVENTORY)`: If the Amazon EC2 dynamic inventory need to be used or no, can be eiter `true`, `false` or `auto`. `auto` checks if `AWS_ACCESS_KEY_ID` is set or not. Default: `auto`.
-  * `(AWS_ACCESS_KEY_ID)`: Used by Amazon EC2 dynamic inventory
-  * `(AWS_SECRET_ACCESS_KEY)`: Used by Amazon EC2 dynamic inventory
+  * `(AWS_ACCESS_KEY_ID)`: Used by Amazon EC2 dynamic inventory or `CY_AWS_CRED` to use Cycloid credential format
+  * `(AWS_SECRET_ACCESS_KEY)`: Used by Amazon EC2 dynamic inventory or `CY_AWS_CRED` to use Cycloid credential format
   * `(EC2_VPC_DESTINATION_VARIABLE)`: Can be either `ip_address` for public ip address or `private_ip_address`, see [ec2.ini](https://github.com/ansible/ansible/blob/devel/contrib/inventory/ec2.ini). Default: `private_ip_address`.
 
 azure_rm vars:
   * `(AZURE_INVENTORY)`: If the Azure dynamic inventory need to be used or no, can be eiter `true`, `false` or `auto`. `auto` checks if `AZURE_SUBSCRIPTION_ID` is set or not. Default: `auto`.
-  * `(AZURE_SUBSCRIPTION_ID)`: Used by Azure dynamic inventory
-  * `(AZURE_TENANT_ID)`: Used by Azure dynamic inventory
-  * `(AZURE_CLIENT_ID)`: Used by Azure dynamic inventory
-  * `(AZURE_SECRET)`: Used by Azure dynamic inventory
+  * `(AZURE_SUBSCRIPTION_ID)`: Used by Azure dynamic inventory or `CY_AZURE_CRED` to use Cycloid credential format
+  * `(AZURE_TENANT_ID)`: Used by Azure dynamic inventory or `CY_AZURE_CRED` to use Cycloid credential format
+  * `(AZURE_CLIENT_ID)`: Used by Azure dynamic inventory or `CY_AZURE_CRED` to use Cycloid credential format
+  * `(AZURE_SECRET)`: Used by Azure dynamic inventory or `CY_AZURE_CRED` to use Cycloid credential format
   * `(AZURE_USE_PRIVATE_IP)`: Can be either `True` or `False`, see [azure_rm.py](https://raw.githubusercontent.com/ansible/ansible/devel/contrib/inventory/azure_rm.py). Default: `True`.
   * `(ANSIBLE_PLUGIN_AZURE_PLAIN_HOST_NAMES)`: By default this plugin will use globally unique host names. This option allows you to override that, and use the name that matches the old inventory script naming.. Default: `False`.
   note: Ansible `azure_rm` plugin is used for ansible `>= 2.8` else `azure_rm.py` script will be used
 
 gcp_compute vars:
   * `(GCP_INVENTORY)`: If the GCP dynamic inventory needs to be used or not, can be either `true`, `false` or `auto`. `auto` checks if `GCP_SERVICE_ACCOUNT_CONTENTS` is set or not. Default: `auto`.
-  * `(GCP_SERVICE_ACCOUNT_CONTENTS)`: Used by GCP dynamic inventory. The GCP Service Account in JSON format.
+  * `(GCP_SERVICE_ACCOUNT_CONTENTS)`: Used by GCP dynamic inventory. The GCP Service Account in JSON format. or `CY_GCP_CRED` to use Cycloid credential format
   * `(GCP_USE_PRIVATE_IP)`: Can be either `True` or `False`. Default: `True`.
 
 vmware_vm_inventory vars:

--- a/scripts/ansible-common.sh
+++ b/scripts/ansible-common.sh
@@ -62,6 +62,23 @@ versionIsHigher() {
   printf '%s\n%s' "$1" "$2" | sort -rC -V
 }
 
+# Allow usage of Cycloid creds for cloud provider access
+if [ -n "$CY_AWS_CRED" ]; then
+    export AWS_ACCESS_KEY_ID=$(echo $CY_AWS_CRED | jq -r .access_key)
+    export AWS_SECRET_ACCESS_KEY=$(echo $CY_AWS_CRED | jq -r .secret_key)
+fi
+
+if [ -n "$CY_AZURE_CRED" ]; then
+    export AZURE_SUBSCRIPTION_ID=$(echo $CY_AZURE_CRED | jq -r .subscription_id)
+    export AZURE_TENANT_ID=$(echo $CY_AZURE_CRED | jq -r .tenant_id)
+    export AZURE_CLIENT_ID=$(echo $CY_AZURE_CRED | jq -r .client_id)
+    export AZURE_SECRET=$(echo $CY_AZURE_CRED | jq -r .client_secret)
+fi
+
+if [ -n "$CY_GCP_CRED" ]; then
+    export GCP_SERVICE_ACCOUNT_CONTENTS=$(echo $CY_GCP_CRED | jq -r .json_key)
+fi
+
 # actionnable callback is now deprecated: ERROR! [DEPRECATED]: community.general.actionable has been removed. Use the 'default' callback plugin with 'display_skipped_hosts = no' and 'display_ok_hosts = no' options. This feature was removed from community.general in version 2.0.0. Please update your playbooks.
 # In order to keep a backward compatibility using the suggested variables with the default callback
 if [ "$ANSIBLE_STDOUT_CALLBACK" == "actionable" ]; then


### PR DESCRIPTION
Allow usage of Cycloid cred as CY_AWS|GCP|AZURE_CRED en var in order to pass cloud provider access keys.