### PR TITLE
adds CY_VMWARE_CRED parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,12 +85,15 @@ GCP gcp_compute inventory:
      - `(GCP_SERVICE_ACCOUNT_CONTENTS)`: Used by GCP dynamic inventory. The GCP Service Account in JSON format.
   * `(GCP_USE_PRIVATE_IP)`: Can be either `True` or `False`. Default: `True`.
 
-vmware_vm_inventory vars:
+VMware Guest inventory:
   * `(VMWARE_VM_INVENTORY)`: If the VMware Guest inventory needs to be used or not, can be either `true`, `false` or `auto`. `auto` checks if `VMWARE_SERVER` is set or not. Default: `auto`.
+  * Cloud access used by VMware inventory
+     - `(CY_VMWARE_CRED)`: Use Cycloid VMWARE credential
+    or
+     - `(VMWARE_USERNAME)`: Used by VMware Guest inventory. Name of vSphere user.
+     - `(VMWARE_PASSWORD)`: Used by VMware Guest inventory. Password of vSphere user.
   * `(VMWARE_SERVER)`: Used by VMware Guest inventory. Name or IP address of vCenter server.
   * `(VMWARE_PORT)`: Used by VMware Guest inventory. Service port of vCenter server. Default: 443
-  * `(VMWARE_USERNAME)`: Used by VMware Guest inventory. Name of vSphere user.
-  * `(VMWARE_PASSWORD)`: Used by VMware Guest inventory. Password of vSphere user.
 
 Example of pipeline configuration :
 

--- a/scripts/ansible-common.sh
+++ b/scripts/ansible-common.sh
@@ -80,6 +80,11 @@ if [ -n "$CY_GCP_CRED" ]; then
     export GCP_SERVICE_ACCOUNT_CONTENTS=$(echo $CY_GCP_CRED | jq -r .json_key)
 fi
 
+if [ -n "$CY_VMWARE_CRED" ]; then
+    export VMWARE_USERNAME=$(echo $CY_VMWARE_CRED | jq -r .username)
+    export VMWARE_PASSWORD=$(echo $CY_VMWARE_CRED | jq -r .password)
+fi
+
 # actionnable callback is now deprecated: ERROR! [DEPRECATED]: community.general.actionable has been removed. Use the 'default' callback plugin with 'display_skipped_hosts = no' and 'display_ok_hosts = no' options. This feature was removed from community.general in version 2.0.0. Please update your playbooks.
 # In order to keep a backward compatibility using the suggested variables with the default callback
 if [ "$ANSIBLE_STDOUT_CALLBACK" == "actionable" ]; then

--- a/scripts/ansible-runner
+++ b/scripts/ansible-runner
@@ -61,12 +61,15 @@ usage()
     echo '     - `(GCP_SERVICE_ACCOUNT_CONTENTS)`: Used by GCP dynamic inventory. The GCP Service Account in JSON format.'
     echo '  * `(GCP_USE_PRIVATE_IP)`: Can be either `True` or `False`. Default: `True`.'
     echo ''
-    echo 'vmware_vm_inventory vars:'
+    echo 'VMware Guest inventory:'
     echo '  * `(VMWARE_VM_INVENTORY)`: If the VMware Guest inventory needs to be used or not, can be either `true`, `false` or `auto`. `auto` checks if `VMWARE_SERVER` is set or not. Default: `auto`.'
+    echo '  * Cloud access used by VMware inventory'
+    echo '     - `(CY_VMWARE_CRED)`: Use Cycloid VMWARE credential'
+    echo '    or'
+    echo '     - `(VMWARE_USERNAME)`: Used by VMware Guest inventory. Name of vSphere user.'
+    echo '     - `(VMWARE_PASSWORD)`: Used by VMware Guest inventory. Password of vSphere user.'
     echo '  * `(VMWARE_SERVER)`: Used by VMware Guest inventory. Name or IP address of vCenter server.'
     echo '  * `(VMWARE_PORT)`: Used by VMware Guest inventory. Service port of vCenter server. Default: 443'
-    echo '  * `(VMWARE_USERNAME)`: Used by VMware Guest inventory. Name of vSphere user.'
-    echo '  * `(VMWARE_PASSWORD)`: Used by VMware Guest inventory. Password of vSphere user.'
     echo ''
     exit 1
 }


### PR DESCRIPTION
Adds the CY_VMWARE_CRED parameter to be able to authenticate vCenter with a Cycloid credential of type VMWARE as it is already the case for AWS, Azure and GCP.

Some tests may need to be added.